### PR TITLE
PIST-430 update facebook related letsencrypt certs

### DIFF
--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -462,7 +462,7 @@ def setup_acme_client(s3_client, acme_directory_url, acme_account_key):
 def acme_client_for_private_key(acme_directory_url, private_key):
     return acme.client.Client(
         # TODO: support EC keys, when josepy does.
-        acme_directory_url, key=josepyself.JWKRSA(key=private_key)
+        acme_directory_url, key=josepy.JWKRSA(key=private_key)
     )
 
 

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -1,16 +1,13 @@
 import datetime
-import json
 import logging
 import os
 import argparse
-import sys
 import textwrap
 import time
 
 import acme.challenges
 import acme.client
 import boto3
-import botocore.exceptions
 import dateutil.tz
 import josepy
 import OpenSSL.crypto
@@ -464,8 +461,8 @@ def setup_acme_client(s3_client, acme_directory_url, acme_account_key):
 
 def acme_client_for_private_key(acme_directory_url, private_key):
     return acme.client.Client(
-        # TODO: support EC keys, when acme.jose does.
-        acme_directory_url, key=acme.jose.JWKRSA(key=private_key)
+        # TODO: support EC keys, when josepy does.
+        acme_directory_url, key=josepyself.JWKRSA(key=private_key)
     )
 
 

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -9,10 +9,10 @@ import time
 
 import acme.challenges
 import acme.client
-import acme.jose
 import boto3
 import botocore.exceptions
 import dateutil.tz
+import josepy
 import OpenSSL.crypto
 import rfc3986
 
@@ -418,7 +418,7 @@ def complete_dns_challenge(acme_client, dns_challenge_completer,
 
 def request_certificate(acme_client, authorizations, csr):
     cert_response, _ = acme_client.poll_and_request_issuance(
-        acme.jose.util.ComparableX509(
+        josepy.util.ComparableX509(
             OpenSSL.crypto.load_certificate_request(
                 OpenSSL.crypto.FILETYPE_ASN1,
                 csr.public_bytes(serialization.Encoding.DER),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ acme[dns]>=0.9
 boto3>=1.2.3
 click>=6.2
 cryptography>=1.1.2
+josepy>=1.0.0
 pyopenssl>=0.15.1
 retry>=0.9.2
 rfc3986>=0.3.1


### PR DESCRIPTION
Tried to run this script to update facebook related letsencrypt certs for the social/incubator team, and got the following:
```
(letsencrypt) bv-nexus 8 ➜  letsencrypt-aws git:(master) ✗ python letsencrypt-aws.py update --key ./lets-encrypt.pem --route53-profile bv-social
Traceback (most recent call last):
  File "letsencrypt-aws.py", line 12, in <module>
    import acme.jose
ImportError: No module named jose
```

I then found [this fix](https://github.com/alex/letsencrypt-aws/pull/101) from the repo we forked from.

Next, I removed unused modules that travisci complained about. (botocore.exceptions, json, sys)  The build then passed.